### PR TITLE
fix(devcontainer): use published Python 3.14 image tag

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "Python 3.14",
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-  "image": "mcr.microsoft.com/devcontainers/python:1.0-3.14-bookworm",
+  "image": "mcr.microsoft.com/devcontainers/python:3-3.14-bookworm",
   "customizations": {
     "codespaces": {
       "openFiles": [


### PR DESCRIPTION
## Problem

Codespaces created from this template fail to build. The devcontainer references an image tag that was never published:

```
mcr.microsoft.com/devcontainers/python:1.0-3.14-bookworm
```

Opening a generated repo in Codespaces errors with:

> No manifest found for mcr.microsoft.com/devcontainers/python:1.0-3.14-bookworm

This was introduced by the uv migration (#30), which changed the image from `1-3.11-bullseye` to `1.0-3.14-bookworm`. Reported by @eduwang in [#30 (comment)](https://github.com/streamlit/blank-app-template/pull/30#issuecomment-5011464961).

## Root cause

The leading `1.0-` is the dev container image's own release version, not the Python version. That prefix family only has builds up through older Python versions (`1.0-3.11`, `1.0-3.10`, ...); no `1.0-3.14` combination was ever published. Python 3.14 only exists under newer image-version prefixes (`2-3.14`, `3-3.14`, `dev-3.14`) and the unprefixed `3.14`.

I verified against the registry manifest API:

| Tag | Manifest |
| --- | --- |
| `1.0-3.14-bookworm` (current) | 404 — does not exist |
| `1-3.14-bookworm` | 404 — does not exist |
| `3-3.14-bookworm` (this PR) | 200 — exists |
| `3.14-bookworm` | 200 — exists |

## Fix

Switch to `python:3-3.14-bookworm`, a published tag that keeps Python 3.14 while pinning a valid image version.

```diff
- "image": "mcr.microsoft.com/devcontainers/python:1.0-3.14-bookworm",
+ "image": "mcr.microsoft.com/devcontainers/python:3-3.14-bookworm",
```

## Testing

- Confirmed `3-3.14-bookworm` resolves on `mcr.microsoft.com` (manifest returns HTTP 200) while the current tag returns 404.